### PR TITLE
Remove `buffer` dependency

### DIFF
--- a/js/moq/package.json
+++ b/js/moq/package.json
@@ -24,8 +24,5 @@
 		"typescript": "^5.8.3",
 		"vite": "^6.3.5",
 		"vite-plugin-html": "^3.2.2"
-	},
-	"dependencies": {
-		"buffer": "^6.0.3"
 	}
 }

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -118,10 +118,6 @@ importers:
         version: 2.11.7(solid-js@1.9.7)(vite@6.3.5(@types/node@24.0.1)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3))
 
   moq:
-    dependencies:
-      buffer:
-        specifier: ^6.0.3
-        version: 6.0.3
     devDependencies:
       '@typescript/lib-dom':
         specifier: npm:@types/web@^0.0.241


### PR DESCRIPTION
#### Summary

Relying on the buffer package is a bit painful because it gets polyfilled automatically, which complicates things further when Node stuff isn't included. While this can be worked around, it requires adding awkward shims like:

```ts
(globalThis as any).numberIsNaN = Number.isNaN;
```

Considering the limited use case (local development) and the specific usage context, I find it cleaner and simpler to replace this with a small custom utility instead.
