### PR TITLE
Fix Firefox audio not playing

### DIFF
--- a/js/hang/src/watch/audio.ts
+++ b/js/hang/src/watch/audio.ts
@@ -72,14 +72,6 @@ export class Audio {
 		const context = new AudioContext({ latencyHint: "interactive", sampleRate });
 		effect.cleanup(() => context.close());
 
-		if (context.state === "suspended") {
-			// We can't create a worklet when the context is suspended.
-			// This happens due to autoplay policies.
-			// Turn ourselves off so there's at least some feedback to the end user.
-			this.enabled.set(false);
-			return;
-		}
-
 		effect.spawn(async () => {
 			// Register the AudioWorklet processor
 			await context.audioWorklet.addModule(WORKLET_URL);


### PR DESCRIPTION
This check for AudioContext state does not work in Firefox as unlike Chromium, Firefox does not automatically set the initial state of the AudioContext to `running`. Removing this check seems to cause no problems as the audio state is set to disabled by default.

More details about the difference of the initial AudioContext state between browsers is discussed here: https://github.com/WebAudio/web-audio-api/issues/2218

This fixes issue: https://github.com/kixelated/moq/issues/463

@kixelated 