### PR TITLE
Fix backwards variable names in connection.rs

### DIFF
--- a/rs/Cargo.lock
+++ b/rs/Cargo.lock
@@ -1390,7 +1390,7 @@ dependencies = [
 
 [[package]]
 name = "moq-relay"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/rs/moq-relay/Cargo.toml
+++ b/rs/moq-relay/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Luke Curley"]
 repository = "https://github.com/kixelated/moq"
 license = "MIT OR Apache-2.0"
 
-version = "0.8.1"
+version = "0.8.2"
 edition = "2021"
 
 keywords = ["quic", "http3", "webtransport", "media", "live"]


### PR DESCRIPTION
## Summary
- Fixed swapped variable names in `connection.rs` that were backwards from their actual behavior
- Added clarifying comment about the relay's perspective on publish/subscribe
- Bumped moq-relay version to 0.8.2

## Details
The variable names were confusing because:
- `publish` was used for broadcasts the session subscribes to
- `subscribe` was used for broadcasts the session publishes

This PR fixes the naming to match the actual semantics. The relay's perspective is backwards from the client's (it publishes what clients subscribe to, and subscribes to what clients publish), which is now documented with a comment.

🤖 Generated with [Claude Code](https://claude.ai/code)