### PR TITLE
Fix double connections

### DIFF
--- a/js/hang/src/connection.ts
+++ b/js/hang/src/connection.ts
@@ -85,9 +85,6 @@ export class Connection {
 				}
 			} catch (err) {
 				console.warn("connection error:", err);
-			} finally {
-				this.established.set(undefined);
-				this.status.set("disconnected");
 
 				if (this.reload) {
 					const tick = this.#tick.peek() + 1;
@@ -99,6 +96,9 @@ export class Connection {
 					// Exponential backoff.
 					this.#delay = Math.min(this.#delay * 2, this.maxDelay);
 				}
+			} finally {
+				this.established.set(undefined);
+				this.status.set("disconnected");
 			}
 		});
 

--- a/js/hang/src/connection.ts
+++ b/js/hang/src/connection.ts
@@ -1,5 +1,5 @@
 import * as Moq from "@kixelated/moq";
-import { type Effect, Root, Signal } from "@kixelated/signals";
+import { type Effect, Root, Signal, Unique } from "@kixelated/signals";
 
 export type ConnectionProps = {
 	// The URL of the relay server.
@@ -21,7 +21,7 @@ export type ConnectionProps = {
 export type ConnectionStatus = "connecting" | "connected" | "disconnected" | "unsupported";
 
 export class Connection {
-	url: Signal<URL | undefined>;
+	url: Unique<URL | undefined>;
 	status = new Signal<ConnectionStatus>("disconnected");
 	established = new Signal<Moq.Connection | undefined>(undefined);
 
@@ -36,7 +36,7 @@ export class Connection {
 	#tick = new Signal(0);
 
 	constructor(props?: ConnectionProps) {
-		this.url = new Signal(props?.url);
+		this.url = new Unique(props?.url);
 		this.reload = props?.reload ?? true;
 		this.delay = props?.delay ?? 1000;
 		this.maxDelay = props?.maxDelay ?? 30000;

--- a/js/hang/src/connection.ts
+++ b/js/hang/src/connection.ts
@@ -68,7 +68,7 @@ export class Connection {
 				const pending = Moq.Connection.connect(url);
 				const connection = await Promise.race([cancel, pending]);
 				if (!connection) {
-					pending.then((conn) => conn.close());
+					pending.then((conn) => conn.close()).catch(() => {});
 					return;
 				}
 

--- a/js/signals/src/react.ts
+++ b/js/signals/src/react.ts
@@ -1,8 +1,8 @@
 import { useSyncExternalStore } from "react";
-import type { Computed, Signal } from "./index";
+import type { Accessor } from "./index";
 
 // A helper to create a React signal.
-export default function react<T>(signal: Signal<T> | Computed<T>): T {
+export default function react<T>(signal: Accessor<T>): T {
 	return useSyncExternalStore(
 		(callback) => signal.subscribe(callback),
 		() => signal.peek(),

--- a/js/signals/src/solid.ts
+++ b/js/signals/src/solid.ts
@@ -1,8 +1,8 @@
-import { type Accessor, createSignal } from "solid-js";
-import type { Computed, Signal } from "./index";
+import { createSignal, type Accessor as SolidAccessor } from "solid-js";
+import type { Accessor } from "./index";
 
 // A helper to create a solid-js signal.
-export default function solid<T>(signal: Signal<T> | Computed<T>): Accessor<T> {
+export default function solid<T>(signal: Accessor<T>): SolidAccessor<T> {
 	const [get, set] = createSignal(signal.peek());
 	signal.subscribe((value) => set(() => value));
 	return get;

--- a/rs/Cargo.lock
+++ b/rs/Cargo.lock
@@ -2981,9 +2981,9 @@ dependencies = [
 
 [[package]]
 name = "web-transport"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11c476f2c40013a2c651393df0fcff40a33e1fc24fddfd3cfa69d2c298018bd0"
+checksum = "8dd16497e7d916fe90639b0b8553bdb3098d488f576c3a825da852ed0e630d59"
 dependencies = [
  "bytes",
  "thiserror 2.0.12",
@@ -3006,9 +3006,9 @@ dependencies = [
 
 [[package]]
 name = "web-transport-quinn"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f9226d1daf46670c9bf83422bf8ff6020c7af549cf7f8159e3dbbb2aed97f3a"
+checksum = "f678f219136b44edb0f264679f6668a41817ccb7cf9098256ff9a359cee8d010"
 dependencies = [
  "aws-lc-rs",
  "bytes",


### PR DESCRIPTION
Two issues:
1. URL as a signal was using === for equality, so it was reloading even if the URL hadn't changed.
2. The previous connection was not getting cleaned up.