### PR TITLE
Fix duplicate JS announcements.

### DIFF
--- a/js/moq/src/lite/publisher.ts
+++ b/js/moq/src/lite/publisher.ts
@@ -91,10 +91,13 @@ export class Publisher {
 			const suffix = Path.stripPrefix(msg.prefix, announcement.name);
 			if (suffix === null) throw new Error("invalid suffix");
 
+			const index = activePaths.indexOf(suffix);
 			if (announcement.active) {
+				if (index !== -1) throw new Error("duplicate announce");
 				activePaths.push(suffix);
 			} else {
-				activePaths.splice(activePaths.indexOf(suffix), 1);
+				if (index === -1) throw new Error("unknown announce");
+				activePaths.splice(index, 1);
 			}
 
 			next = consumer.next();

--- a/js/moq/src/lite/publisher.ts
+++ b/js/moq/src/lite/publisher.ts
@@ -50,20 +50,12 @@ export class Publisher {
 				active: true,
 			});
 
-			console.debug(`announce: broadcast=${name} active=true`);
-
 			// Wait until the broadcast is closed, then remove it from the lookup.
 			await broadcast.closed();
-
-			console.debug(`announce: broadcast=${name} active=false`);
-		} catch (err: unknown) {
-			const e = error(err);
-			console.warn(`announce: broadcast=${name} error=${e.message}`);
 		} finally {
 			broadcast.close();
 
 			this.#broadcasts.delete(name);
-
 			this.#announced.write({
 				name,
 				active: false,
@@ -83,10 +75,29 @@ export class Publisher {
 
 		// Send ANNOUNCE_INIT as the first message with all currently active paths
 		const activePaths: Path.Valid[] = [];
-		for (const [name] of this.#broadcasts) {
-			const suffix = Path.stripPrefix(msg.prefix, name);
-			if (suffix === null) continue;
-			activePaths.push(suffix);
+
+		// Make a resolved promise so we can avoid blocking.
+		// This abuses the fact that Promise.race will prioritize the first resolved promise.
+		const timeout = Promise.resolve();
+
+		let next = consumer.next();
+
+		for (;;) {
+			const announcement = await Promise.race([next, timeout]);
+			if (!announcement) break;
+
+			console.debug(`announce: broadcast=${announcement.name} active=${announcement.active} init=true`);
+
+			const suffix = Path.stripPrefix(msg.prefix, announcement.name);
+			if (suffix === null) throw new Error("invalid suffix");
+
+			if (announcement.active) {
+				activePaths.push(suffix);
+			} else {
+				activePaths.splice(activePaths.indexOf(suffix), 1);
+			}
+
+			next = consumer.next();
 		}
 
 		const init = new AnnounceInit(activePaths);
@@ -94,12 +105,18 @@ export class Publisher {
 
 		// Then send updates as they occur
 		for (;;) {
-			const announcement = await consumer.next();
+			const announcement = await next;
 			if (!announcement) break;
+
+			console.debug(`announce: broadcast=${announcement.name} active=${announcement.active} init=false`);
 
 			const wire = new Announce(announcement.name, announcement.active);
 			await wire.encode(stream.writer);
+
+			next = consumer.next();
 		}
+
+		consumer.close();
 	}
 
 	/**
@@ -201,5 +218,15 @@ export class Publisher {
 		} finally {
 			group.close();
 		}
+	}
+
+	close() {
+		this.#announced.close();
+
+		for (const broadcast of this.#broadcasts.values()) {
+			broadcast.close();
+		}
+
+		this.#broadcasts.clear();
 	}
 }

--- a/js/moq/src/lite/subscriber.ts
+++ b/js/moq/src/lite/subscriber.ts
@@ -186,4 +186,12 @@ export class Subscriber {
 			producer.abort(error(err));
 		}
 	}
+
+	close() {
+		for (const track of this.#subscribes.values()) {
+			track.close();
+		}
+
+		this.#subscribes.clear();
+	}
 }

--- a/rs/Cargo.lock
+++ b/rs/Cargo.lock
@@ -2240,9 +2240,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.29"
+version = "0.23.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2491382039b29b9b11ff08b76ff6c97cf287671dbb74f0be44bda389fffe9bd1"
+checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
 dependencies = [
  "aws-lc-rs",
  "log",

--- a/rs/Cargo.lock
+++ b/rs/Cargo.lock
@@ -540,9 +540,9 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
@@ -1421,7 +1421,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.2",
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -2077,9 +2077,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.15"
+version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8af0dde094006011e6a740d4879319439489813bd0bcdc7d821beaeeff48ec"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
  "bitflags",
 ]
@@ -2196,9 +2196,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.25"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustc-hash"
@@ -2773,9 +2773,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.46.1"
+version = "1.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17"
+checksum = "43864ed400b6043a4757a25c7a64a8efde741aed79a056a2fb348a406701bb35"
 dependencies = [
  "backtrace",
  "bytes",
@@ -2786,9 +2786,9 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "slab",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "tokio-macros",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3484,7 +3484,7 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.2",
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -3520,10 +3520,11 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.2"
+version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",


### PR DESCRIPTION
The logic was wrong because it didn't partially consume. This is a little hackier, as it abuses Promice.race to get the synchronous announcements, but it's fine if it doesn't work anyway.

The `next` variable is needed otherwise the first announcement update is gobbled.

Oh and I fixed some logging related to the connection being closed.