### PR TITLE
Fix paths so they're relative to the root, not root + role.

### DIFF
--- a/js/moq/src/lite/connection.ts
+++ b/js/moq/src/lite/connection.ts
@@ -226,6 +226,7 @@ export async function connect(url: URL): Promise<Connection> {
 	if (url.protocol === "http:") {
 		const fingerprintUrl = new URL(url);
 		fingerprintUrl.pathname = "/certificate.sha256";
+		fingerprintUrl.search = "";
 		console.warn(fingerprintUrl.toString(), "performing an insecure fingerprint fetch; use https:// in production");
 
 		// Fetch the fingerprint from the server.

--- a/rs/moq/src/error.rs
+++ b/rs/moq/src/error.rs
@@ -54,6 +54,9 @@ pub enum Error {
 
 	#[error("protocol violation")]
 	ProtocolViolation,
+
+	#[error("unauthorized")]
+	Unauthorized,
 }
 
 impl Error {
@@ -66,6 +69,7 @@ impl Error {
 			Self::Timeout => 3,
 			Self::WebTransport(_) => 4,
 			Self::Decode(_) => 5,
+			Self::Unauthorized => 6,
 			Self::Version(..) => 9,
 			Self::UnexpectedStream(_) => 10,
 			Self::BoundsExceeded(_) => 11,


### PR DESCRIPTION
Previously, all announcements and subscriptions would be relative to the role.

So if you were allowed to consume /foo and publish /foo/bar.

SUBSCRIBE "baz" would reference /foo/baz
while
ANNOUNCE "baz" would reference /foo/bar/baz

This broke my app and is super confusing because the path depdends on the role. I thought I was publishing bar but I was actually publishing bar/bar

Dunno quite how this worked before.