### PR TITLE
Save the preferred device when the user is prompted?

### DIFF
--- a/js/hang/src/publish/source/device.ts
+++ b/js/hang/src/publish/source/device.ts
@@ -123,10 +123,19 @@ export class Device<Kind extends "audio" | "video"> {
 
 	// Manually request permission for the device, ignoring the result.
 	requestPermission() {
+		if (this.permission.peek()) return;
+
 		navigator.mediaDevices
 			.getUserMedia({ [this.kind]: true })
 			.then((stream) => {
 				this.permission.set(true);
+
+				// If the user selected a device during the dialog prompt, save it as the preferred device.
+				const deviceId = stream.getTracks().at(0)?.getSettings().deviceId;
+				if (deviceId) {
+					this.preferred.set(deviceId);
+				}
+
 				stream.getTracks().forEach((track) => {
 					track.stop();
 				});

--- a/js/hang/src/publish/source/microphone.ts
+++ b/js/hang/src/publish/source/microphone.ts
@@ -36,7 +36,7 @@ export class Microphone {
 		const constraints = effect.get(this.constraints) ?? {};
 		const finalConstraints: MediaTrackConstraints = {
 			...constraints,
-			deviceId: device ? { exact: device } : undefined,
+			deviceId: device !== undefined ? { exact: device } : undefined,
 		};
 
 		effect.spawn(async (cancel) => {
@@ -61,6 +61,11 @@ export class Microphone {
 			if (!track) return;
 
 			const settings = track.getSettings();
+
+			if (device === undefined) {
+				// Save the device that the user selected during the dialog prompt.
+				this.device.preferred.set(settings.deviceId);
+			}
 
 			effect.set(this.device.active, settings.deviceId);
 			effect.set(this.stream, track);


### PR DESCRIPTION
If we request an undefined device with no permission, browsers will prompt the user. We want to save their selection as the device we should use when available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The app now remembers your selected microphone or input device for future sessions when chosen from the prompt.

* **Bug Fixes**
  * Prevents redundant permission prompts and media requests when access is already granted.
  * Correctly honors edge-case device IDs (including empty strings) to ensure the intended device is used.
  * Improves media access stability by gracefully handling errors to avoid user interruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->