### PR TITLE
Improve the WebTransport/WebSocket options you can pass.

### DIFF
--- a/js/hang/package.json
+++ b/js/hang/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@kixelated/hang",
 	"type": "module",
-	"version": "0.4.0",
+	"version": "0.4.1",
 	"description": "Media over QUIC library",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:kixelated/moq",

--- a/js/moq/package.json
+++ b/js/moq/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@kixelated/moq",
 	"type": "module",
-	"version": "0.8.0",
+	"version": "0.8.1",
 	"description": "Media over QUIC library",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:kixelated/moq",

--- a/js/signals/package.json
+++ b/js/signals/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@kixelated/signals",
 	"type": "module",
-	"version": "0.6.0",
+	"version": "0.6.1",
 	"description": "Reactive and safe signals",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:kixelated/moq",

--- a/rs/Cargo.lock
+++ b/rs/Cargo.lock
@@ -1473,7 +1473,7 @@ dependencies = [
 
 [[package]]
 name = "moq-relay"
-version = "0.8.10"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/rs/moq-relay/Cargo.toml
+++ b/rs/moq-relay/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Luke Curley"]
 repository = "https://github.com/kixelated/moq"
 license = "MIT OR Apache-2.0"
 
-version = "0.8.10"
+version = "0.9.0"
 edition = "2021"
 
 keywords = ["quic", "http3", "webtransport", "media", "live"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Granular reconnection settings: enable/disable with configurable initial and maximum delay.
  * Per-connection WebSocket fallback options: enable/disable, custom delay, and custom WS URL.
  * WebTransport configuration support.

* **Behavior Changes**
  * Reconnection backoff now follows the new reload settings and defaults.
  * WebSocket fallback only runs when enabled; delay and URL come from options.
  * Connection attempts consider both WebTransport and WebSocket for smarter fallback timing.

* **Chores**
  * Minor package version bumps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->