### PR TITLE
Actually enable the proper rustls features.

### DIFF
--- a/rs/Cargo.lock
+++ b/rs/Cargo.lock
@@ -843,7 +843,7 @@ dependencies = [
 
 [[package]]
 name = "hang-cli"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "anyhow",
  "axum",
@@ -1446,7 +1446,7 @@ dependencies = [
 
 [[package]]
 name = "moq-native"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1473,7 +1473,7 @@ dependencies = [
 
 [[package]]
 name = "moq-relay"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/rs/hang-cli/Cargo.toml
+++ b/rs/hang-cli/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Luke Curley <kixelated@gmail.com>"]
 repository = "https://github.com/kixelated/moq"
 license = "MIT OR Apache-2.0"
 
-version = "0.2.7"
+version = "0.2.8"
 edition = "2021"
 
 keywords = ["quic", "http3", "webtransport", "media", "live"]

--- a/rs/moq-native/Cargo.toml
+++ b/rs/moq-native/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Luke Curley"]
 repository = "https://github.com/kixelated/moq"
 license = "MIT OR Apache-2.0"
 
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 
 keywords = ["quic", "http3", "webtransport", "media", "live"]

--- a/rs/moq-native/Cargo.toml
+++ b/rs/moq-native/Cargo.toml
@@ -11,6 +11,11 @@ edition = "2021"
 keywords = ["quic", "http3", "webtransport", "media", "live"]
 categories = ["multimedia", "network-programming", "web-programming"]
 
+[features]
+default = ["aws-lc-rs"]
+aws-lc-rs = ["rustls/aws-lc-rs"]
+ring = ["rustls/ring"]
+
 [dependencies]
 
 anyhow = { version = "1", features = ["backtrace"] }

--- a/rs/moq-relay/Cargo.toml
+++ b/rs/moq-relay/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Luke Curley"]
 repository = "https://github.com/kixelated/moq"
 license = "MIT OR Apache-2.0"
 
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 
 keywords = ["quic", "http3", "webtransport", "media", "live"]


### PR DESCRIPTION
Technically the issue is in hyper_serve, but I'd rather just fix moq-native.

```
Sep 04 19:54:43 relay-us-central docker[1101]: thread 'tokio-runtime-worker' panicked at /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-vendor-cargo-deps/c19b7c6f923b580ac259164a89f2577984ad5ab09ee9d583b888f934adbbe8d0/rustls-0.23.31/src/crypto/mod.rs:249:14:
Sep 04 19:54:43 relay-us-central docker[1101]: Could not automatically determine the process-level CryptoProvider from Rustls crate features.
Sep 04 19:54:43 relay-us-central docker[1101]: Call CryptoProvider::install_default() before this point to select a provider manually, or make sure exactly one of the 'aws-lc-rs' and 'ring' features is enabled.
Sep 04 19:54:43 relay-us-central docker[1101]: See the documentation of the CryptoProvider type for more information.
Sep 04 19:54:43 relay-us-central docker[1101]:             
Sep 04 19:54:43 relay-us-central docker[1101]: stack backtrace:
Sep 04 19:54:43 relay-us-central docker[1101]:    0: __rustc::rust_begin_unwind
Sep 04 19:54:43 relay-us-central docker[1101]:    1: core::panicking::panic_fmt
Sep 04 19:54:43 relay-us-central docker[1101]:    2: core::option::expect_failed
Sep 04 19:54:43 relay-us-central docker[1101]:    3: rustls::server::server_conn::ServerConfig::builder_with_protocol_versions
Sep 04 19:54:43 relay-us-central docker[1101]:    4: rustls::server::server_conn::ServerConfig::builder
Sep 04 19:54:43 relay-us-central docker[1101]:    5: hyper_serve::tls_rustls::config_from_der
Sep 04 19:54:43 relay-us-central docker[1101]:    6: hyper_serve::tls_rustls::config_from_pem
Sep 04 19:54:43 relay-us-central docker[1101]:    7: moq_relay::main::{{closure}}::{{closure}}
Sep 04 19:54:43 relay-us-central docker[1101]:    8: tokio::runtime::task::core::Core<T,S>::poll
Sep 04 19:54:43 relay-us-central docker[1101]:    9: tokio::runtime::task::harness::Harness<T,S>::poll
Sep 04 19:54:43 relay-us-central docker[1101]:   10: tokio::runtime::scheduler::multi_thread::worker::Context::run_task
Sep 04 19:54:43 relay-us-central docker[1101]:   11: tokio::runtime::scheduler::multi_thread::worker::Context::run
Sep 04 19:54:43 relay-us-central docker[1101]:   12: tokio::runtime::context::scoped::Scoped<T>::set
Sep 04 19:54:43 relay-us-central docker[1101]:   13: tokio::runtime::context::runtime::enter_runtime
Sep 04 19:54:43 relay-us-central docker[1101]:   14: tokio::runtime::scheduler::multi_thread::worker::run
Sep 04 19:54:43 relay-us-central docker[1101]:   15: <tokio::runtime::blocking::task::BlockingTask<T> as core::future::future::Future>::poll
Sep 04 19:54:43 relay-us-central docker[1101]:   16: tokio::runtime::task::core::Core<T,S>::poll
Sep 04 19:54:43 relay-us-central docker[1101]:   17: tokio::runtime::task::harness::Harness<T,S>::poll
Sep 04 19:54:43 relay-us-central docker[1101]: note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added optional TLS backend selection for the native module with a default backend enabled.

- Chores
  - Version bump for hang-cli to 0.2.8.
  - Version bump for moq-native to 0.8.1.
  - Version bump for moq-relay to 0.9.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->