### PR TITLE
Remove gst fully

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,6 @@ If you don't like Nix, then you can install dependencies manually:
 - [Node.js](https://nodejs.org/)
 - [pnpm](https://pnpm.io/)
 - [FFmpeg](https://ffmpeg.org/download.html)
-- [GStreamer](https://gstreamer.freedesktop.org/documentation/installing/index.html) (optional)
 - [Deno](https://deno.com/runtime) (optional)
 - ...probably some other stuff
 

--- a/js/hang-demo/src/index.html
+++ b/js/hang-demo/src/index.html
@@ -148,13 +148,9 @@ just pub bbb
 		Yeah it's pretty gross.
 	</p>
 	<p>
-		If you want to do things more efficiently, you can use the <i>alpha</i> gstreamer plugin via:
-		<code class="language-bash">just pub-gst tos</code>.
+		If you want to do things more efficiently, you can use the GStreamer plugin from the separate
+		<a href="https://github.com/kixelated/hang-gst">hang-gst repository</a>.
 		It's pretty crude and doesn't handle all pipeline events; contributions welcome!
-	</p>
-	<p>
-		And if you're feeing extra adventurous, use <code class="language-bash">just sub-gst tos</code> to <i>watch</i>
-		via gstreamer.
 	</p>
 </body>
 

--- a/js/hang-demo/src/publish.html
+++ b/js/hang-demo/src/publish.html
@@ -85,13 +85,9 @@ publish.broadcast.audio.enabled.set(true);</code></pre>
 		Yeah it's pretty gross.
 	</p>
 	<p>
-		If you want to do things more efficiently, you can use the <i>alpha</i> gstreamer plugin via:
-		<code class="language-bash">just pub-gst tos</code>.
+		If you want to do things more efficiently, you can use the GStreamer plugin from the separate
+		<a href="https://github.com/kixelated/hang-gst">hang-gst repository</a>.
 		It's pretty crude and doesn't handle all pipeline events; contributions welcome!
-	</p>
-	<p>
-		And if you're feeing extra adventurous, use <code class="language-bash">just sub-gst tos</code> to <i>watch</i>
-		via gstreamer.
 	</p>
 	<hr />
 	<p>

--- a/justfile
+++ b/justfile
@@ -70,13 +70,15 @@ leaf:
 pub name url='http://localhost:4443/anon':
 	just --justfile rs/justfile pub {{name}} {{url}}
 
-# Publish a video using gstreamer to the localhost relay server
+# Publish/subscribe using gstreamer - see https://github.com/kixelated/hang-gst
 pub-gst name url='http://localhost:4443/anon':
-	just --justfile rs/justfile pub-gst {{name}} {{url}}
+	@echo "GStreamer plugin has moved to: https://github.com/kixelated/hang-gst"
+	@echo "Install and use hang-gst directly for GStreamer functionality"
 
-# Subscribe to a video using gstreamer
+# Subscribe to a video using gstreamer - see https://github.com/kixelated/hang-gst  
 sub name url='http://localhost:4443/anon':
-	just --justfile rs/justfile sub {{name}} {{url}}
+	@echo "GStreamer plugin has moved to: https://github.com/kixelated/hang-gst"
+	@echo "Install and use hang-gst directly for GStreamer functionality"
 
 # Publish a video using ffmpeg directly from hang to the localhost
 serve name:

--- a/rs/flake.nix
+++ b/rs/flake.nix
@@ -43,16 +43,6 @@
 
         craneLib = (crane.mkLib pkgs).overrideToolchain rust-toolchain;
 
-        gst-deps = with pkgs.gst_all_1; [
-          gstreamer
-          gst-plugins-base
-          gst-plugins-good
-          gst-plugins-bad
-          gst-plugins-ugly
-          gst-plugins-rs
-          gst-libav
-        ];
-
         shell-deps =
           with pkgs;
           [
@@ -65,8 +55,8 @@
             curl
             cargo-sort
             cargo-shear
-          ]
-          ++ gst-deps;
+            cargo-edit
+          ];
 
         # Helper function to get crate info from Cargo.toml
         crateInfo = cargoTomlPath: craneLib.crateNameFromCargoToml { cargoToml = cargoTomlPath; };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Removed inline GStreamer instructions from README and demo pages; now link to the Hang-GST repository for guidance.

- Chores
  - Disabled in-repo GStreamer publish/subscribe Justfile commands; they now print instructions to use Hang-GST instead.
  - Updated related Justfile comments to reference Hang-GST.

- Build/Dev Environment
  - Removed GStreamer dependencies from the Nix flake development shell.
  - Added cargo-edit to the development shell.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->