### PR TITLE
Add a video jitter buffer.

### DIFF
--- a/js/hang/src/watch/audio/ring-buffer.ts
+++ b/js/hang/src/watch/audio/ring-buffer.ts
@@ -86,14 +86,14 @@ export class AudioRingBuffer {
 		// Write the actual samples
 		for (let channel = 0; channel < this.channels; channel++) {
 			let src = data[channel];
-			src = src.slice(src.length - samples);
+			src = src.subarray(src.length - samples);
 
 			const dst = this.#buffer[channel];
 			if (src.length !== samples) throw new Error("mismatching number of samples");
 
 			for (let i = 0; i < samples; i++) {
 				const writePos = (start + i) % dst.length;
-				dst[writePos] = src[offset + i];
+				dst[writePos] = src[i];
 			}
 		}
 

--- a/js/hang/src/watch/audio/ring-buffer.ts
+++ b/js/hang/src/watch/audio/ring-buffer.ts
@@ -85,7 +85,9 @@ export class AudioRingBuffer {
 
 		// Write the actual samples
 		for (let channel = 0; channel < this.channels; channel++) {
-			const src = data[channel];
+			let src = data[channel];
+			src = src.slice(src.length - samples);
+
 			const dst = this.#buffer[channel];
 			if (src.length !== samples) throw new Error("mismatching number of samples");
 

--- a/js/hang/src/watch/audio/source.ts
+++ b/js/hang/src/watch/audio/source.ts
@@ -1,8 +1,8 @@
-import * as Moq from "@kixelated/moq";
+import type * as Moq from "@kixelated/moq";
 import { Effect, type Getter, Signal } from "@kixelated/signals";
-import * as Catalog from "../../catalog";
+import type * as Catalog from "../../catalog";
 import * as Frame from "../../frame";
-import * as Time from "../../time";
+import type * as Time from "../../time";
 import * as Hex from "../../util/hex";
 import * as libav from "../../util/libav";
 import { PRIORITY } from "../priority";
@@ -20,7 +20,7 @@ export type SourceProps = {
 	enabled?: boolean | Signal<boolean>;
 
 	// The latency hint to use for the AudioContext.
-	latency?: Time.Milli;
+	latency?: Time.Milli | Signal<Time.Milli>;
 
 	// Enable to download the captions track.
 	captions?: CaptionsProps;
@@ -55,7 +55,7 @@ export class Source {
 	speaking: Speaking;
 
 	// Not a signal because I'm lazy.
-	readonly latency: Time.Milli;
+	readonly latency: Signal<Time.Milli>;
 
 	#signals = new Effect();
 
@@ -67,7 +67,7 @@ export class Source {
 		this.broadcast = broadcast;
 		this.catalog = catalog;
 		this.enabled = Signal.from(props?.enabled ?? false);
-		this.latency = props?.latency ?? (100 as Time.Milli); // TODO Reduce this once fMP4 stuttering is fixed.
+		this.latency = Signal.from(props?.latency ?? (100 as Time.Milli)); // TODO Reduce this once fMP4 stuttering is fixed.
 		this.captions = new Captions(broadcast, this.info, props?.captions);
 		this.speaking = new Speaking(broadcast, this.info, props?.speaking);
 
@@ -119,7 +119,7 @@ export class Source {
 				type: "init",
 				rate: sampleRate,
 				channels: channelCount,
-				latency: this.latency,
+				latency: this.latency.peek(), // TODO make it reactive
 			};
 			worklet.port.postMessage(init);
 
@@ -152,6 +152,12 @@ export class Source {
 		const sub = broadcast.subscribe(info.track, PRIORITY.audio);
 		effect.cleanup(() => sub.close());
 
+		// Create consumer with slightly less latency than the render worklet to avoid underflowing.
+		const consumer = new Frame.Consumer(sub, {
+			latency: Math.max(this.latency.peek() - JITTER_UNDERHEAD, 0) as Time.Milli,
+		});
+		effect.cleanup(() => consumer.close());
+
 		effect.spawn(async () => {
 			const loaded = await libav.polyfill();
 			if (!loaded) return; // cancelled
@@ -162,19 +168,11 @@ export class Source {
 			});
 			effect.cleanup(() => decoder.close());
 
-			const config = info.config;
-			const description = config.description ? Hex.toBytes(config.description) : undefined;
-
+			const description = info.config.description ? Hex.toBytes(info.config.description) : undefined;
 			decoder.configure({
-				...config,
+				...info.config,
 				description,
 			});
-
-			// Create consumer with slightly less latency than the render worklet to avoid underflowing.
-			const consumer = new Frame.Consumer(sub, {
-				latency: Math.max(this.latency - JITTER_UNDERHEAD, 0) as Time.Milli,
-			});
-			effect.cleanup(() => consumer.close());
 
 			for (;;) {
 				const frame = await consumer.decode();

--- a/js/hang/src/watch/audio/source.ts
+++ b/js/hang/src/watch/audio/source.ts
@@ -19,7 +19,7 @@ export type SourceProps = {
 	// Enable to download the audio track.
 	enabled?: boolean | Signal<boolean>;
 
-	// The latency hint to use for the AudioContext.
+	// Jitter buffer size in milliseconds (default: 100ms)
 	latency?: Time.Milli | Signal<Time.Milli>;
 
 	// Enable to download the captions track.

--- a/js/hang/src/watch/video/source.ts
+++ b/js/hang/src/watch/video/source.ts
@@ -1,7 +1,8 @@
-import * as Moq from "@kixelated/moq";
+import type * as Moq from "@kixelated/moq";
 import { Effect, type Getter, Signal } from "@kixelated/signals";
-import * as Catalog from "../../catalog";
+import type * as Catalog from "../../catalog";
 import * as Frame from "../../frame";
+import * as Time from "../../time";
 import * as Hex from "../../util/hex";
 import { PRIORITY } from "../priority";
 import { Detection, type DetectionProps } from "./detection";
@@ -9,6 +10,7 @@ import { Detection, type DetectionProps } from "./detection";
 export type SourceProps = {
 	enabled?: boolean | Signal<boolean>;
 	detection?: DetectionProps;
+	latency?: Time.Milli | Signal<Time.Milli>;
 };
 
 // Responsible for switching between video tracks and buffering frames.
@@ -24,12 +26,9 @@ export class Source {
 
 	detection: Detection;
 
-	// Unfortunately, browsers don't let us hold on to multiple VideoFrames.
-	// TODO To support higher latencies, keep around the encoded data and decode on demand.
-	// ex. Firefox only allows 2 outstanding VideoFrames at a time.
-	// We hold a second frame buffered as a crude way to introduce latency to sync with audio.
 	frame = new Signal<VideoFrame | undefined>(undefined);
-	#next?: VideoFrame;
+
+	latency: Signal<Time.Milli>;
 
 	#signals = new Effect();
 
@@ -40,6 +39,7 @@ export class Source {
 	) {
 		this.broadcast = broadcast;
 		this.catalog = catalog;
+		this.latency = Signal.from(props?.latency ?? (100 as Time.Milli));
 		this.enabled = Signal.from(props?.enabled ?? false);
 		this.detection = new Detection(this.broadcast, this.catalog, props?.detection);
 
@@ -68,24 +68,18 @@ export class Source {
 		const sub = broadcast.subscribe(info.track, PRIORITY.video);
 		effect.cleanup(() => sub.close());
 
+		// Create consumer that reorders groups/frames up to the provided latency.
+		const consumer = new Frame.Consumer(sub, {
+			latency: this.latency,
+		});
+		effect.cleanup(() => consumer.close());
+
 		const decoder = new VideoDecoder({
 			output: (frame) => {
-				if (!this.frame.peek()) {
-					this.frame.set(frame);
-					return;
-				}
-
-				if (!this.#next) {
-					this.#next = frame;
-					return;
-				}
-
 				this.frame.update((prev) => {
 					prev?.close();
-					return this.#next;
+					return frame;
 				});
-
-				this.#next = frame;
 			},
 			// TODO bubble up error
 			error: (error) => {
@@ -105,30 +99,33 @@ export class Source {
 		});
 
 		effect.spawn(async () => {
+			let reference: DOMHighResTimeStamp | undefined;
+
 			for (;;) {
-				const next = await sub.readFrameSequence();
+				const next = await consumer.decode();
 				if (!next) break;
 
-				const decoded = Frame.decode(next.data);
+				const ref = performance.now() - Time.Milli.fromMicro(next.timestamp);
+				if (!reference || ref < reference) {
+					reference = ref;
+				} else {
+					const sleep = reference - ref + this.latency.peek();
+					await new Promise((resolve) => setTimeout(resolve, sleep));
+				}
+
+				if (decoder.state === "closed") {
+					// Closed during the sleep
+					break;
+				}
 
 				const chunk = new EncodedVideoChunk({
-					type: next.frame === 0 ? "key" : "delta",
-					data: decoded.data,
-					timestamp: decoded.timestamp,
+					type: next.keyframe ? "key" : "delta",
+					data: next.data,
+					timestamp: next.timestamp,
 				});
 
 				decoder.decode(chunk);
 			}
-		});
-
-		effect.cleanup(() => {
-			this.frame.update((frame) => {
-				frame?.close();
-				return undefined;
-			});
-
-			this.#next?.close();
-			this.#next = undefined;
 		});
 	}
 
@@ -138,8 +135,6 @@ export class Source {
 			return undefined;
 		});
 
-		this.#next?.close();
-		this.#next = undefined;
 		this.#signals.close();
 
 		this.detection.close();

--- a/js/hang/src/watch/video/source.ts
+++ b/js/hang/src/watch/video/source.ts
@@ -10,6 +10,7 @@ import { Detection, type DetectionProps } from "./detection";
 export type SourceProps = {
 	enabled?: boolean | Signal<boolean>;
 	detection?: DetectionProps;
+	// Jitter buffer size in milliseconds (default: 100ms)
 	latency?: Time.Milli | Signal<Time.Milli>;
 };
 


### PR DESCRIPTION
And fix some existing bugs with the existing audio jitter buffer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Latency is now reactive and accepts either a numeric value or a signal; HangWatch exposes a latency attribute/property (default 100 ms) that updates in real time to coordinate decode and render.
  * Video and audio playback use latency-aware consumers for buffering and timing.

* **Bug Fixes**
  * Improved frame ordering/skipping and more reliable resource cleanup.
  * Audio buffer now writes the latest samples window to maintain consistent output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->