### PR TITLE
Add timestamp to effect.animate.

### DIFF
--- a/js/signals/src/index.ts
+++ b/js/signals/src/index.ts
@@ -358,7 +358,7 @@ export class Effect {
 	}
 
 	// Run the callback on the next animation frame, unless the effect is cleaned up first.
-	animate(fn: () => void) {
+	animate(fn: (now: DOMHighResTimeStamp) => void) {
 		if (this.#dispose === undefined) {
 			if (DEV) {
 				console.warn("Effect.animate called when closed, ignoring");
@@ -366,8 +366,8 @@ export class Effect {
 			return;
 		}
 
-		let animate: number | undefined = requestAnimationFrame(() => {
-			fn();
+		let animate: number | undefined = requestAnimationFrame((now) => {
+			fn(now);
 			animate = undefined;
 		});
 		this.cleanup(() => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Animation callbacks now receive a high‑resolution frame timestamp for each frame, enabling precise timing, delta calculations, and smoother animations.
  * Behavior remains the same otherwise; use the provided timestamp to synchronize animations or measure elapsed time.
  * TypeScript users should update callback signatures to accept a DOMHighResTimeStamp parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->