### PR TITLE
Fix Chrome flipping the frame twice.

### DIFF
--- a/js/hang/src/watch/video/source.ts
+++ b/js/hang/src/watch/video/source.ts
@@ -178,6 +178,8 @@ export class Source {
 			...selected.config,
 			description,
 			optimizeForLatency: selected.config.optimizeForLatency ?? true,
+			// @ts-expect-error Only supported by Chrome, so the renderer has to flip manually.
+			flip: false,
 		});
 
 		effect.spawn(async () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrects video orientation for the selected video track on Chrome by enabling a decoder flip option, improving visual accuracy without affecting latency or other settings. Behavior on non-Chrome browsers remains unchanged, with existing rendering paths preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->